### PR TITLE
Added Gresham's Law

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,18 @@ See also:
 > In economics, Gresham's law is a monetary principle stating that "bad money drives out good". 
 > For example, if there are two forms of commodity money in circulation, which are accepted by law as having similar face value, the more valuable commodity will gradually disappear from circulation.
 
+> Under Gresham's Law, "good money" is money that shows little difference between its nominal value (the face value of the coin) and its commodity value (the value of the metal of which it is made, often precious metals, nickel, or copper).
+
+> In the absence of legal-tender laws, metal coin money will freely exchange at somewhat above bullion market value. This may be observed in bullion coins such as the Canadian Gold Maple Leaf, the South African Krugerrand, the American Gold Eagle, or even the silver Maria Theresa thaler (Austria) and the Libertad (Mexico). Coins of this type are of a known purity and are in a convenient form to handle. People prefer trading in coins rather than in anonymous hunks of precious metal, so they attribute more value to the coins of equal weight.
+
+> The price spread between face value and commodity value is called seigniorage. As some coins do not circulate, remaining in the possession of coin collectors, this can increase demand for coinage.
+
+> On the other hand, bad money is money that has a commodity value considerably lower than its face value and is in circulation along with good money, where both forms are required to be accepted at equal value as legal tender.
+
+> In Gresham's day, bad money included any coin that had been debased. Debasement was often done by the issuing body, where less than the officially specified amount of precious metal was contained in an issue of coinage, usually by alloying it with a base metal. The public could also debase coins, usually by clipping or scraping off small portions of the precious metal, also known as "stemming" (reeded edges on coins were intended to make clipping evident). Other examples of bad money include counterfeit coins made from base metal. Today all circulating coins are made from base metals, known as fiat money.
+
+> In the case of clipped, scraped, or counterfeit coins, the commodity value was reduced by fraud, as the face value remains at the previous higher level. On the other hand, with a coinage debased by a government issuer, the commodity value of the coinage was often reduced quite openly, while the face value of the debased coins was held at the higher level by legal tender laws.
+
 ### Hanlon's Razor
 
 [Hanlon's Razor on Wikipedia](https://en.wikipedia.org/wiki/Hanlon%27s_razor)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Like this project? Please considering [Sponsoring Me](https://github.com/sponsor
     * [Cunningham's Law](#cunninghams-law)
     * [Dunbar's Number](#dunbars-number)
     * [Gall's Law](#galls-law)
+    * [Greshem's Law](#greshems-law)
     * [Hanlon's Razor](#hanlons-razor)
     * [Hofstadter's Law](#hofstadters-law)
     * [Hutber's Law](#hutbers-law)
@@ -161,6 +162,13 @@ The classic example is the world-wide-web. In it's current state, it is a highly
 See also:
 
 - [KISS (Keep It Simple, Stupid)](#the-kiss-principle)
+
+### Greshem's Law 
+
+[Greshem's Law on Wikipedia](https://en.wikipedia.org/wiki/Gresham%27s_law)[Gresham's Law](#Gresham's_law)
+
+> In economics, Gresham's law is a monetary principle stating that "bad money drives out good". 
+> For example, if there are two forms of commodity money in circulation, which are accepted by law as having similar face value, the more valuable commodity will gradually disappear from circulation.
 
 ### Hanlon's Razor
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Like this project? Please considering [Sponsoring Me](https://github.com/sponsor
     * [Cunningham's Law](#cunninghams-law)
     * [Dunbar's Number](#dunbars-number)
     * [Gall's Law](#galls-law)
-    * [Greshem's Law](#greshems-law)
+    * [Gresham's Law](#greshams-law)
     * [Hanlon's Razor](#hanlons-razor)
     * [Hofstadter's Law](#hofstadters-law)
     * [Hutber's Law](#hutbers-law)
@@ -163,9 +163,9 @@ See also:
 
 - [KISS (Keep It Simple, Stupid)](#the-kiss-principle)
 
-### Greshem's Law 
+### Gresham's Law 
 
-[Greshem's Law on Wikipedia](https://en.wikipedia.org/wiki/Gresham%27s_law)
+[Gresham's Law on Wikipedia](https://en.wikipedia.org/wiki/Gresham%27s_law)
 
 > In economics, Gresham's law is a monetary principle stating that "bad money drives out good". 
 > For example, if there are two forms of commodity money in circulation, which are accepted by law as having similar face value, the more valuable commodity will gradually disappear from circulation.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ See also:
 
 ### Greshem's Law 
 
-[Greshem's Law on Wikipedia](https://en.wikipedia.org/wiki/Gresham%27s_law)[Gresham's Law](#Gresham's_law)
+[Greshem's Law on Wikipedia](https://en.wikipedia.org/wiki/Gresham%27s_law)
 
 > In economics, Gresham's law is a monetary principle stating that "bad money drives out good". 
 > For example, if there are two forms of commodity money in circulation, which are accepted by law as having similar face value, the more valuable commodity will gradually disappear from circulation.


### PR DESCRIPTION
In economics, Gresham's law is a monetary principle stating that "bad money drives out good". For example, if there are two forms of commodity money in circulation, which are accepted by law as having similar face value, the more valuable commodity will gradually disappear from circulation.[1][2]

Under Gresham's Law, "good money" is money that shows little difference between its nominal value (the face value of the coin) and its commodity value (the value of the metal of which it is made, often precious metals, nickel, or copper).

In the absence of legal-tender laws, metal coin money will freely exchange at somewhat above bullion market value. This may be observed in bullion coins such as the Canadian Gold Maple Leaf, the South African Krugerrand, the American Gold Eagle, or even the silver Maria Theresa thaler (Austria) and the Libertad (Mexico). Coins of this type are of a known purity and are in a convenient form to handle. People prefer trading in coins rather than in anonymous hunks of precious metal, so they attribute more value to the coins of equal weight.

The price spread between face value and commodity value is called seigniorage. As some coins do not circulate, remaining in the possession of coin collectors, this can increase demand for coinage.

On the other hand, bad money is money that has a commodity value considerably lower than its face value and is in circulation along with good money, where both forms are required to be accepted at equal value as legal tender.

In Gresham's day, bad money included any coin that had been debased. Debasement was often done by the issuing body, where less than the officially specified amount of precious metal was contained in an issue of coinage, usually by alloying it with a base metal. The public could also debase coins, usually by clipping or scraping off small portions of the precious metal, also known as "stemming" (reeded edges on coins were intended to make clipping evident). Other examples of bad money include counterfeit coins made from base metal. Today all circulating coins are made from base metals, known as fiat money.

In the case of clipped, scraped, or counterfeit coins, the commodity value was reduced by fraud, as the face value remains at the previous higher level. On the other hand, with a coinage debased by a government issuer, the commodity value of the coinage was often reduced quite openly, while the face value of the debased coins was held at the higher level by legal tender laws.