### PR TITLE
Fix inverted author name for The Dilbert Principle

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ If you have found these concepts interesting, you may enjoy the following books.
 - [Extreme Programming Installed - Ron Jeffries, Ann Anderson, Chet Hendrikson](https://www.goodreads.com/en/book/show/67834) - Covers the core principles of Extreme Programming.
 - [The Mythical Man Month - Frederick P. Brooks Jr.](https://www.goodreads.com/book/show/13629.The_Mythical_Man_Month) - A classic volume on software engineering. [Brooks' Law](#brooks-law) is a central theme of the book.
 - [Gödel, Escher, Bach: An Eternal Golden Braid - Douglas R. Hofstadter.](https://www.goodreads.com/book/show/24113.G_del_Escher_Bach) - This book is difficult to classify. [Hofstadter's Law](#hofstadters-law) is from the book.
-- [The Dilbert Principle - Adam Scott](https://www.goodreads.com/book/show/85574.The_Dilbert_Principle) - A comic look at corporate America, from the author who created the [Dilbert Principle](#the-dilbert-principl).
+- [The Dilbert Principle - Scott Adams](https://www.goodreads.com/book/show/85574.The_Dilbert_Principle) - A comic look at corporate America, from the author who created the [Dilbert Principle](#the-dilbert-principle).
 - [The Peter Principle - Lawrence J. Peter](https://www.goodreads.com/book/show/890728.The_Peter_Principle) - Another comic look at the challenges of larger organisations and people management, the source of [The Peter Principle](#the-peter-principle).
 
 ## TODO


### PR DESCRIPTION
Fix author name and incorrect anchor for the-dilbert-principle

**Pull Request Checklist**

Please double check the items below!

- [x] I have read the [Contributor Guidelines](./.github/contributing.md).
- [x] I have not directly copied text from another location (unless explicitly indicated as a quote) or violated copyright.
- [x] I have linked to the original Law.
- [x] I have quote the law (if possible) and the author's name (if possible).
- [x] I am happy to have my changes merged, so that I appear as a contributor, but also the text altered if required to keep the language consistent in the project.

And don't forget:

- I can handle the table of contents, feel free to leave it out.
- Check to see if other laws should link back to the law you have added.
- Include your **Twitter Handle** if you want me to include you when tweeting this update!
