### PR TITLE
Fixed wrong url on link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Laws, Theories, Principles and Patterns that developers will find useful.
 
 - 🇨🇳 [中文 / Chinese Version](https://github.com/nusr/hacker-laws-zh) - thanks [Steve Xu](https://github.com/nusr)!
-- 🇮🇹 [Traduzione in Italiano](https://github.com/csparpa/hacker-laws-it) - grazie [Claudio Sparpaglione](https://github.com/csparpa)!
+- 🇮🇹 [Traduzione in Italiano](https://github.com/dwmkerr/hacker-laws/blob/master/translations/it-IT.md) - grazie [Claudio Sparpaglione](https://github.com/csparpa)!
 - 🇰🇷 [한국어 / Korean Version](https://github.com/codeanddonuts/hacker-laws-kr) - thanks [Doughnut](https://github.com/codeanddonuts)!
 - 🇷🇺 [Русская версия / Russian Version](https://github.com/solarrust/hacker-laws) - thanks [Alena Batitskaya](https://github.com/solarrust)!
 - 🇹🇷 [Türkçe / Turkish Version](https://github.com/umutphp/hacker-laws-tr) - thanks [Umut Işık](https://github.com/umutphp)


### PR DESCRIPTION
The current link for the Italian version takes you to the wrong location. 
This PR fixes that.

**Pull Request Checklist**

Please double check the items below!

- [x] I have read the [Contributor Guidelines](./.github/contributing.md).
- [ ] I have not directly copied text from another location (unless explicitly indicated as a quote) or violated copyright.
- [ ] I have linked to the original Law.
- [ ] I have quote the law (if possible) and the author's name (if possible).
- [x] I am happy to have my changes merged, so that I appear as a contributor, but also the text altered if required to keep the language consistent in the project.

And don't forget:

- I can handle the table of contents, feel free to leave it out.
- Check to see if other laws should link back to the law you have added.
- Include your **Twitter Handle** if you want me to include you when tweeting this update!
