### PR TITLE
Add Tip of the Day as a related project (#229)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Like this project? Please considering [Sponsoring Me](https://github.com/sponsor
     * [YAGNI](#yagni)
     * [The Fallacies of Distributed Computing](#the-fallacies-of-distributed-computing)
 * [Reading List](#reading-list)
+* [Related Projects](#related-projects)
 * [Contributing](#contributing)
 * [TODO](#todo)
 
@@ -767,6 +768,10 @@ If you have found these concepts interesting, you may enjoy the following books.
 - [Gödel, Escher, Bach: An Eternal Golden Braid - Douglas R. Hofstadter.](https://www.goodreads.com/book/show/24113.G_del_Escher_Bach) - This book is difficult to classify. [Hofstadter's Law](#hofstadters-law) is from the book.
 - [The Dilbert Principle - Scott Adams](https://www.goodreads.com/book/show/85574.The_Dilbert_Principle) - A comic look at corporate America, from the author who created the [Dilbert Principle](#the-dilbert-principle).
 - [The Peter Principle - Lawrence J. Peter](https://www.goodreads.com/book/show/890728.The_Peter_Principle) - Another comic look at the challenges of larger organisations and people management, the source of [The Peter Principle](#the-peter-principle).
+
+## Related Projects
+
+- [Tip of the Day](https://tips.darekkay.com/html/hacker-laws-en.html) - Receive a daily hacker law/principle.
 
 ## Contributing
 


### PR DESCRIPTION
As discussed in #229, I have added [Tip of the Day](https://tips.darekkay.com/html/hacker-laws-en.html) as a "related project". I felt like it didn't fit into the existing "reading list" section. Instead, I've added a new section, based on how [buku](https://github.com/jarun/buku#related-projects) handles it. Feel free to move the section and/or link around.

**Pull Request Checklist**

Please double check the items below!

- [x] I have read the [Contributor Guidelines](./.github/contributing.md).
- [x] I have not directly copied text from another location (unless explicitly indicated as a quote) or violated copyright.
- [x] I have linked to the original Law.
- [x] I have quote the law (if possible) and the author's name (if possible).
- [x] I am happy to have my changes merged, so that I appear as a contributor, but also the text altered if required to keep the language consistent in the project.
- [x] Twitter handle: [@darekkay](https://twitter.com/darek_kay)

