### PR TITLE
Fix section's links

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The CAP Theorem (defined by Eric Brewer) states that for a distributed data stor
 - Availability: when reading data, every request receives _a non error response_, without the guarantee that it is the _most recent_ data
 - Partition Tolerance: when an arbitrary number of network requests between nodes fail, the system continues to operate as expected
 
-The core of the reasoning is as follows. It is impossible to guarantee that a network partition will not occur (see [The Fallacies of Distributed Computing](#The_Fallacies_of_Distributed_Computing)). Therefore in the case of a partition we can either cancel the operation (increasing consistency and decreasing availability) or proceed (increasing availability but decreasing consistency).
+The core of the reasoning is as follows. It is impossible to guarantee that a network partition will not occur (see [The Fallacies of Distributed Computing](#the-fallacies-of-distributed-computing)). Therefore in the case of a partition we can either cancel the operation (increasing consistency and decreasing availability) or proceed (increasing availability but decreasing consistency).
 
 The name comes from the first letters of the guarantees (Consistency, Availability, Partition Tolerance). Note that it is very important to be aware that this does _not_ relate to [_ACID_](#TODO), which has a different definition of consistency. More recently, [PACELC](#TODO) theorem has been developed which adds constraints for latency and consistency when the network is _not_ partitioned (i.e. when the system is operating as expected).
 
@@ -181,7 +181,7 @@ Real world examples:
 See also:
 
 - [ACID](#TODO)
-- [The Fallacies of Distributed Computing](#The_Fallacies_of_Distributed_Computing)
+- [The Fallacies of Distributed Computing](#the-fallacies-of-distributed-computing)
 - [PACELC](#TODO)
 
 ### Conway's Law
@@ -735,7 +735,7 @@ Related to:
 
 See also:
 
-- [Pareto Principle](#the-pareto-principle)
+- [Pareto Principle](#the-pareto-principle-the-8020-rule)
 
 ### The Peter Principle
 


### PR DESCRIPTION
Corrected wrong self-links for the following sections:
* The Fallacies of Distributed Computing
* The Pareto Principle (The 80/20 Rule)

Note: I used [this short snippet I made](https://gist.github.com/leocaraballo/83e370917f248e70a179926535a6ecfc) to search for non-working self-links in the document from the browser's console.
If you think it's worth it, maybe we can refactor and add it as a PR check via GitHub's workflows.
