### PR TITLE
Updated the link concerning software entropy

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ See also:
 
 Examples:
 
-- [The Pragmatic Programming: Software Entropy](https://pragprog.com/the-pragmatic-programmer/extracts/software-entropy)
+- [The Pragmatic Programming: Software Entropy](https://flylib.com/books/en/1.315.1.15/1/)
 - [Coding Horror: The Broken Window Theory](https://blog.codinghorror.com/the-broken-window-theory/)
 - [OpenSource: Joy of Programming - The Broken Window Theory](https://opensourceforu.com/2011/05/joy-of-programming-broken-window-theory/)
 


### PR DESCRIPTION
The previous [link](https://pragprog.com/the-pragmatic-programmer/extracts/software-entropy) concerning software entropy shows a page not found message -

![Screenshot from 2020-11-12 01-17-13](https://user-images.githubusercontent.com/30027932/98854593-f636c680-2484-11eb-809d-b41acee33616.png)

Replaced the underlying link with a valid one.