### PR TITLE
Change in "The Two Pizza Rule"

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,7 +622,7 @@ Members of the organisation have described that the actual meaning of these grou
 >
 > (Jeff Bezos)
 
-This rule suggests that regardless of the size of the company, teams should be small enough to be fed by two pizzas. Attributed to Jeff Bezos and Amazon, this belief is suggests that large teams are inherently inefficient. This is supported by the fact that as the team size increases linearly, the links between people increases exponentially; thus the cost of coordinating and communicating also grows exponentially. If this cost of coordination is essentially overhead, then smaller teams should be preferred.
+This rule suggests that regardless of the size of the company, teams should be small enough to be fed by two pizzas. Attributed to Jeff Bezos and Amazon, this belief is suggests that large teams are inherently inefficient. This is supported by the fact that as the team size increases linearly, the links between people increases quadratically; thus the cost of coordinating and communicating also grows quadratically. If this cost of coordination is essentially overhead, then smaller teams should be preferred.
 
 The number of links between people can be expressed as `n(n-1)/2` where n = number of people.
 


### PR DESCRIPTION
In "The Two Pizza Rule" there is the following statement: 

> This is supported by the fact that as the team size increases linearly, the links between people increases exponentially; thus the cost of coordinating and communicating also grows exponentially.

But clearly the links growth is _quadratic_. The author even acknowledge that:

> The number of links between people can be expressed as n(n-1)/2 where n = number of people.

**Pull Request Checklist**

Please double check the items below!

- [ ] I have read the [Contributor Guidelines](https://github.com/dwmkerr/hacker-laws/blob/master/.github/contributing.md).
- [ ] I have not directly copied text from another location (unless explicitly indicated as a quote) or violated copyright.
- [ ] I have linked to the original Law.
- [ ] I have quote the law (if possible) and the author's name (if possible).
- [ ] I am happy to have my changes merged, so that I appear as a contributor, but also the text altered if required to keep the language consistent in the project.

And don't forget:

- I can handle the table of contents, feel free to leave it out.
- Check to see if other laws should link back to the law you have added.
- Include your **Twitter Handle** if you want me to include you when tweeting this update!
